### PR TITLE
fix: support large blocks and verbosity=1 nodes

### DIFF
--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -1394,7 +1394,7 @@ class BlocksRepository {
         } else {
           // Call Core RPC
           const block = await bitcoinClient.getBlock(dbBlk.id, true);
-          summary = blocks.summarizeBlock(block);
+          summary = await blocks.summarizeBlock(block);
         }
 
         await BlocksSummariesRepository.$saveTransactions(

--- a/backend/src/utils/file-read.ts
+++ b/backend/src/utils/file-read.ts
@@ -4,7 +4,10 @@ import config from '../config';
 
 function readFile(filePath: string, bufferSize?: number): string[] {
   const fileSize = fs.statSync(filePath).size;
-  const chunkSize = bufferSize || fileSize;
+  if (fileSize === 0) {
+    return [];
+  }
+  const chunkSize = Math.min(bufferSize || fileSize, fileSize);
   const fileDescriptor = fs.openSync(filePath, 'r');
   const buffer = Buffer.alloc(chunkSize);
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "mempool-frontend",
-      "version": "3.2.0-dev",
+      "version": "3.3-dev",
       "license": "GNU Affero General Public License v3.0",
       "dependencies": {
         "@angular-devkit/build-angular": "^17.3.1",
@@ -32,6 +32,7 @@
         "bootstrap": "~4.6.2",
         "browserify": "^17.0.0",
         "clipboard": "^2.0.11",
+        "crypto-js": "^4.2.0",
         "domino": "^2.1.6",
         "echarts": "~5.6.0",
         "esbuild": "^0.24.0",
@@ -7899,6 +7900,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css-loader": {
       "version": "6.10.0",
@@ -23868,6 +23875,11 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "css-loader": {
       "version": "6.10.0",

--- a/frontend/sync-assets.js
+++ b/frontend/sync-assets.js
@@ -122,6 +122,10 @@ function downloadMiningPoolLogos$() {
           }
           let downloadedCount = 0;
           for (const poolLogo of poolLogos) {
+            // Skip directories and entries without download_url
+            if (poolLogo.type !== 'file' || !poolLogo.download_url) {
+              continue;
+            }
             if (verbose) {
               console.log(`${LOG_TAG} Processing ${poolLogo.name}`);
             }


### PR DESCRIPTION
## Summary
- Increase `tx_count` column size from SMALLINT to INT UNSIGNED to support blocks with more than 65535 transactions
- Fix file-read.ts to handle small debug.log files (prevent negative position error)
- Support nodes that return `getblock verbosity=1` format (txid strings instead of full transaction objects)
- config change:
  - mempool backend `"BLOCKS_SUMMARIES_INDEXING": true`: enable summary indexing, avoid realtime calculation
  - mariadb: `--max-allowed-packet=1GB`: to support maxium 8m txs in a block

## Test plan
- [ ] Verify large blocks (100k+ txs) can be indexed without `Out of range value for column 'tx_count'` error
- [ ] Verify block summary indexing works with nodes that don't support `getblock verbosity=2`
- [ ] Verify no errors when debug.log is small or empty