### PR TITLE
fix: use CAST(... as SIGNED) for MySQL compatibility

### DIFF
--- a/backend/src/api/explorer/nodes.api.ts
+++ b/backend/src/api/explorer/nodes.api.ts
@@ -12,8 +12,8 @@ class NodesApi {
     try {
       let query = `
         SELECT nodes.public_key as publicKey, IF(nodes.alias = '', SUBSTRING(nodes.public_key, 1, 20), alias) as alias,
-        CAST(COALESCE(nodes.capacity, 0) as INT) as capacity,
-        CAST(COALESCE(nodes.channels, 0) as INT) as channels,
+        CAST(COALESCE(nodes.capacity, 0) as SIGNED) as capacity,
+        CAST(COALESCE(nodes.channels, 0) as SIGNED) as channels,
         nodes.longitude, nodes.latitude,
         geo_names_country.names as country, geo_names_iso.names as isoCode
         FROM nodes
@@ -299,8 +299,8 @@ class NodesApi {
       } else {
         query = `
           SELECT nodes.public_key AS publicKey, IF(nodes.alias = '', SUBSTRING(nodes.public_key, 1, 20), alias) as alias,
-            CAST(COALESCE(nodes.capacity, 0) as INT) as capacity,
-            CAST(COALESCE(nodes.channels, 0) as INT) as channels,
+            CAST(COALESCE(nodes.capacity, 0) as SIGNED) as capacity,
+            CAST(COALESCE(nodes.channels, 0) as SIGNED) as channels,
             UNIX_TIMESTAMP(nodes.first_seen) as firstSeen, UNIX_TIMESTAMP(nodes.updated_at) as updatedAt,
             geo_names_city.names as city, geo_names_country.names as country,
             geo_names_iso.names as iso_code, geo_names_subdivision.names as subdivision
@@ -360,8 +360,8 @@ class NodesApi {
       } else {
         query = `
           SELECT nodes.public_key AS publicKey, IF(nodes.alias = '', SUBSTRING(nodes.public_key, 1, 20), alias) as alias,
-            CAST(COALESCE(nodes.channels, 0) as INT) as channels,
-            CAST(COALESCE(nodes.capacity, 0) as INT) as capacity,
+            CAST(COALESCE(nodes.channels, 0) as SIGNED) as channels,
+            CAST(COALESCE(nodes.capacity, 0) as SIGNED) as capacity,
             UNIX_TIMESTAMP(nodes.first_seen) as firstSeen, UNIX_TIMESTAMP(nodes.updated_at) as updatedAt,
             geo_names_city.names as city, geo_names_country.names as country,
             geo_names_iso.names as iso_code, geo_names_subdivision.names as subdivision
@@ -413,8 +413,8 @@ class NodesApi {
       } else {
         query = `
           SELECT node_stats.public_key AS publicKey, IF(nodes.alias = '', SUBSTRING(node_stats.public_key, 1, 20), alias) as alias,
-            CAST(COALESCE(node_stats.channels, 0) as INT) as channels,
-            CAST(COALESCE(node_stats.capacity, 0) as INT) as capacity,
+            CAST(COALESCE(node_stats.channels, 0) as SIGNED) as channels,
+            CAST(COALESCE(node_stats.capacity, 0) as SIGNED) as capacity,
             UNIX_TIMESTAMP(nodes.first_seen) as firstSeen, UNIX_TIMESTAMP(nodes.updated_at) as updatedAt,
             geo_names_city.names as city, geo_names_country.names as country,
             geo_names_iso.names as iso_code, geo_names_subdivision.names as subdivision
@@ -596,7 +596,7 @@ class NodesApi {
   public async $getNodesPerCountry(countryId: string) {
     try {
       const query = `
-        SELECT nodes.public_key, CAST(COALESCE(nodes.capacity, 0) as INT) as capacity, CAST(COALESCE(nodes.channels, 0) as INT) as channels,
+        SELECT nodes.public_key, CAST(COALESCE(nodes.capacity, 0) as SIGNED) as capacity, CAST(COALESCE(nodes.channels, 0) as SIGNED) as channels,
           nodes.alias, UNIX_TIMESTAMP(nodes.first_seen) as first_seen, UNIX_TIMESTAMP(nodes.updated_at) as updated_at,
           geo_names_city.names as city, geo_names_country.names as country,
           geo_names_iso.names as iso_code, geo_names_subdivision.names as subdivision,
@@ -666,7 +666,7 @@ class NodesApi {
       }
 
       query = `
-        SELECT nodes.public_key, CAST(COALESCE(nodes.capacity, 0) as INT) as capacity, CAST(COALESCE(nodes.channels, 0) as INT) as channels,
+        SELECT nodes.public_key, CAST(COALESCE(nodes.capacity, 0) as SIGNED) as capacity, CAST(COALESCE(nodes.channels, 0) as SIGNED) as channels,
           nodes.alias, UNIX_TIMESTAMP(nodes.first_seen) as first_seen, UNIX_TIMESTAMP(nodes.updated_at) as updated_at,
           geo_names_city.names as city, geo_names_country.names as country,
           geo_names_iso.names as iso_code, geo_names_subdivision.names as subdivision,

--- a/backend/src/repositories/BlocksRepository.ts
+++ b/backend/src/repositories/BlocksRepository.ts
@@ -810,9 +810,9 @@ class BlocksRepository {
   ): Promise<any> {
     try {
       let query = `SELECT
-        CAST(AVG(blocks.height) as INT) as avgHeight,
-        CAST(AVG(UNIX_TIMESTAMP(blockTimestamp)) as INT) as timestamp,
-        CAST(AVG(fees) as INT) as avgFees,
+        CAST(AVG(blocks.height) as SIGNED) as avgHeight,
+        CAST(AVG(UNIX_TIMESTAMP(blockTimestamp)) as SIGNED) as timestamp,
+        CAST(AVG(fees) as SIGNED) as avgFees,
         prices.USD
         FROM blocks
         JOIN blocks_prices on blocks_prices.height = blocks.height
@@ -847,9 +847,9 @@ class BlocksRepository {
   ): Promise<any> {
     try {
       let query = `SELECT
-        CAST(AVG(blocks.height) as INT) as avgHeight,
-        CAST(AVG(UNIX_TIMESTAMP(blockTimestamp)) as INT) as timestamp,
-        CAST(AVG(reward) as INT) as avgRewards,
+        CAST(AVG(blocks.height) as SIGNED) as avgHeight,
+        CAST(AVG(UNIX_TIMESTAMP(blockTimestamp)) as SIGNED) as timestamp,
+        CAST(AVG(reward) as SIGNED) as avgRewards,
         prices.USD
         FROM blocks
         JOIN blocks_prices on blocks_prices.height = blocks.height
@@ -882,15 +882,15 @@ class BlocksRepository {
   ): Promise<any> {
     try {
       let query = `SELECT
-        CAST(AVG(height) as INT) as avgHeight,
-        CAST(AVG(UNIX_TIMESTAMP(blockTimestamp)) as INT) as timestamp,
-        CAST(AVG(JSON_EXTRACT(fee_span, '$[0]')) as INT) as avgFee_0,
-        CAST(AVG(JSON_EXTRACT(fee_span, '$[1]')) as INT) as avgFee_10,
-        CAST(AVG(JSON_EXTRACT(fee_span, '$[2]')) as INT) as avgFee_25,
-        CAST(AVG(JSON_EXTRACT(fee_span, '$[3]')) as INT) as avgFee_50,
-        CAST(AVG(JSON_EXTRACT(fee_span, '$[4]')) as INT) as avgFee_75,
-        CAST(AVG(JSON_EXTRACT(fee_span, '$[5]')) as INT) as avgFee_90,
-        CAST(AVG(JSON_EXTRACT(fee_span, '$[6]')) as INT) as avgFee_100
+        CAST(AVG(height) as SIGNED) as avgHeight,
+        CAST(AVG(UNIX_TIMESTAMP(blockTimestamp)) as SIGNED) as timestamp,
+        CAST(AVG(JSON_EXTRACT(fee_span, '$[0]')) as SIGNED) as avgFee_0,
+        CAST(AVG(JSON_EXTRACT(fee_span, '$[1]')) as SIGNED) as avgFee_10,
+        CAST(AVG(JSON_EXTRACT(fee_span, '$[2]')) as SIGNED) as avgFee_25,
+        CAST(AVG(JSON_EXTRACT(fee_span, '$[3]')) as SIGNED) as avgFee_50,
+        CAST(AVG(JSON_EXTRACT(fee_span, '$[4]')) as SIGNED) as avgFee_75,
+        CAST(AVG(JSON_EXTRACT(fee_span, '$[5]')) as SIGNED) as avgFee_90,
+        CAST(AVG(JSON_EXTRACT(fee_span, '$[6]')) as SIGNED) as avgFee_100
       FROM blocks`;
 
       if (interval !== null) {
@@ -919,9 +919,9 @@ class BlocksRepository {
   ): Promise<any> {
     try {
       let query = `SELECT
-        CAST(AVG(height) as INT) as avgHeight,
-        CAST(AVG(UNIX_TIMESTAMP(blockTimestamp)) as INT) as timestamp,
-        CAST(AVG(size) as INT) as avgSize
+        CAST(AVG(height) as SIGNED) as avgHeight,
+        CAST(AVG(UNIX_TIMESTAMP(blockTimestamp)) as SIGNED) as timestamp,
+        CAST(AVG(size) as SIGNED) as avgSize
       FROM blocks`;
 
       if (interval !== null) {
@@ -950,9 +950,9 @@ class BlocksRepository {
   ): Promise<any> {
     try {
       let query = `SELECT
-        CAST(AVG(height) as INT) as avgHeight,
-        CAST(AVG(UNIX_TIMESTAMP(blockTimestamp)) as INT) as timestamp,
-        CAST(AVG(weight) as INT) as avgWeight
+        CAST(AVG(height) as SIGNED) as avgHeight,
+        CAST(AVG(UNIX_TIMESTAMP(blockTimestamp)) as SIGNED) as timestamp,
+        CAST(AVG(weight) as SIGNED) as avgWeight
       FROM blocks`;
 
       if (interval !== null) {

--- a/backend/src/repositories/DifficultyAdjustmentsRepository.ts
+++ b/backend/src/repositories/DifficultyAdjustmentsRepository.ts
@@ -32,8 +32,8 @@ class DifficultyAdjustmentsRepository {
     interval = Common.getSqlInterval(interval);
 
     let query = `SELECT 
-      CAST(AVG(UNIX_TIMESTAMP(time)) as INT) as time,
-      CAST(AVG(height) AS INT) as height,
+      CAST(AVG(UNIX_TIMESTAMP(time)) as SIGNED) as time,
+      CAST(AVG(height) AS SIGNED) as height,
       CAST(AVG(difficulty) as DOUBLE) as difficulty,
       CAST(AVG(adjustment) as DOUBLE) as adjustment
       FROM difficulty_adjustments`;

--- a/backend/src/repositories/HashratesRepository.ts
+++ b/backend/src/repositories/HashratesRepository.ts
@@ -60,7 +60,7 @@ class HashratesRepository {
     interval = Common.getSqlInterval(interval);
 
     let query = `SELECT
-      CAST(AVG(UNIX_TIMESTAMP(hashrate_timestamp)) as INT) as timestamp,
+      CAST(AVG(UNIX_TIMESTAMP(hashrate_timestamp)) as SIGNED) as timestamp,
       CAST(AVG(avg_hashrate) as DOUBLE) as avgHashrate
       FROM hashrates`;
 


### PR DESCRIPTION
## Summary
- Fixed SQL syntax error: MySQL does not support `CAST(... as INT)`
- Changed all occurrences to use `CAST(... as SIGNED)` which is valid MySQL syntax
- Affects 4 files: HashratesRepository, DifficultyAdjustmentsRepository, BlocksRepository, nodes.api

## Test plan
- [ ] Restart mempool-backend service
- [ ] Verify no more SQL syntax errors in logs
- [ ] Confirm mining hashrate history API works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)