### PR TITLE
ci: add claude-pr-review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,16 @@
+name: Claude Code PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  claude-review:
+    uses: OPCAT-Labs/common-tools/.github/workflows/claude-pr-review.yml@main
+    secrets:
+      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Add Claude Code PR review workflow using `OPCAT-Labs/common-tools` reusable workflow
- Enables automated code review on all PRs

## Test plan
- [ ] Verify workflow triggers on PR events
- [ ] Confirm secrets pass through correctly