### PR TITLE
fix: remove environment protection from build job in deploy-mempool-gcp workflow

### DIFF
--- a/.github/workflows/deploy-mempool-gcp.yml
+++ b/.github/workflows/deploy-mempool-gcp.yml
@@ -44,8 +44,6 @@ jobs:
   build:
     name: Build Mempool
     runs-on: ubuntu-latest
-    environment:
-      name: mainnet-prod
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The `Deploy Mempool to GCP` workflow has been failing on the `opcat-dev` branch with:

```
Branch "opcat-dev" is not allowed to deploy to mainnet-prod due to environment protection rules.
```

This has caused 3+ consecutive CI failures since 2026-03-14.

## Root Cause

The `build` job had `environment: mainnet-prod` set, which triggers GitHub's environment protection rules. The `opcat-dev` branch is not in the allowed branches for the `mainnet-prod` environment, so the build job is immediately rejected before any code runs.

**The build job does not need the `mainnet-prod` environment** — it only builds the frontend and backend artifacts. The environment is only needed by the `deploy` job for GCP Workload Identity authentication.

Note: The workflow-level `env:` vars (BACKEND_PORT, etc.) are still populated via `vars.*` — these are repository variables, not environment-specific, so they work without the environment restriction.

## Fix

Remove `environment: mainnet-prod` from the `build` job. The `deploy` job already has this environment set correctly.

## Testing

After merge to `opcat-dev`, the next push should trigger a successful build job, followed by the deploy job using GCP credentials from the `mainnet-prod` environment.