### PR TITLE
fix(backend): websocket heartbeat to keep long-lived connections alive

### DIFF
--- a/backend/src/api/websocket-handler.ts
+++ b/backend/src/api/websocket-handler.ts
@@ -117,9 +117,34 @@ class WebsocketHandler {
 
     // TODO - Fix indentation after PR is merged
     for (const server of this.webSocketServers) {
+    // Heartbeat: ping every client periodically and terminate any that didn't
+    // respond to the previous ping. This keeps idle connections alive through
+    // proxy/browser idle timeouts and reaps dead/half-open sockets that would
+    // otherwise leak into server.clients indefinitely.
+    const heartbeatInterval = setInterval(() => {
+      server.clients.forEach((client) => {
+        if (client['isAlive'] === false) {
+          client.terminate();
+          return;
+        }
+        client['isAlive'] = false;
+        try {
+          client.ping();
+        } catch (e) {
+          client.terminate();
+        }
+      });
+    }, 30000);
+    server.on('close', () => {
+      clearInterval(heartbeatInterval);
+    });
     server.on('connection', (client: WebSocket, req) => {
       this.numConnected++;
       client['remoteAddress'] = req.headers['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown';
+      client['isAlive'] = true;
+      client.on('pong', () => {
+        client['isAlive'] = true;
+      });
       client.on('error', (e) => {
         logger.info(`websocket client error from ${client['remoteAddress']}: ` + (e instanceof Error ? e.message : e));
         client.close();

--- a/nginx-mempool.conf
+++ b/nginx-mempool.conf
@@ -121,6 +121,9 @@
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "Upgrade";
+		# WebSocket is long-lived; don't drop idle connections at the default 60s.
+		proxy_read_timeout 3600s;
+		proxy_send_timeout 3600s;
 	}
 
 	# API v1 - main backend
@@ -147,4 +150,7 @@
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection "Upgrade";
+		# WebSocket is long-lived; don't drop idle connections at the default 60s.
+		proxy_read_timeout 3600s;
+		proxy_send_timeout 3600s;
 	}


### PR DESCRIPTION
## Problem
Long-lived WebSocket connections drop after idle periods.

Root cause (two layers):
1. **No server-side heartbeat.** `setupConnectionHandling()` only handled `error`/`close`/`message` — there was no protocol-level ping/pong. The server only pushes data on block/mempool activity, so during quiet on-chain periods a connection can be silent for >60s.
2. **nginx default `proxy_read_timeout` is 60s** on the `/ws` locations, so it silently closes those idle upstream connections.

Secondary: with no liveness probe, half-open/dead clients leaked into `server.clients` indefinitely (only cleared by OS TCP keepalive ~2h), bloating broadcast loops and memory over long uptime.

## Fix
**`backend/src/api/websocket-handler.ts`**
- Per-server 30s heartbeat: `ping()` every client; `terminate()` any that missed the previous `pong` — keeps idle connections alive (<60s traffic through nginx) and reaps dead/half-open sockets within two rounds.
- Track `isAlive` per client via the `pong` handler.
- `clearInterval` on `server.close` to avoid timer leaks.

**`nginx-mempool.conf`**
- Raise `proxy_read_timeout`/`proxy_send_timeout` to 3600s on `/api/v1/ws` and `/ws` as a fallback for non-conforming clients.

Mirrors the existing ping/terminate pattern already used in `api/services/acceleration.ts` (backend-as-client), now applied to the public WS server.

## Verification
- `tsc --noEmit` clean.
- Deploy note: backend needs rebuild + pm2 restart; nginx needs `nginx -t && nginx -s reload`.